### PR TITLE
main: New hash table in the ami object to keep track of the open file pointers

### DIFF
--- a/ami/lib/include/ami/ami.h
+++ b/ami/lib/include/ami/ami.h
@@ -80,6 +80,7 @@ struct _ami_t {
   int repeat_indices_cursor[MAX_NESTED_REPEAT];  
   int current_repeat_block;
   size_t global_counter;
+  khash_t(varhash) *open_files;
 };
 typedef struct _ami_t ami_t;
 
@@ -109,6 +110,8 @@ char *ami_get_nested_variable_as_str(ami_t *ami, ami_node_t *node, char *var_val
 int ami_get_nested_variable_as_int(ami_t *ami, char *var_value);
 int ami_append_sleep_cursor(ami_t *ami, const char *group, float cursor);
 float ami_get_new_sleep_cursor(ami_t *ami, const char *group);
+FILE *ami_get_open_file(ami_t *ami, const char *filename);
+int ami_set_open_file(ami_t *ami, const char *filename, FILE *fp);
   
 #ifdef __cplusplus
 }

--- a/ami/lib/include/ami/csvread.h
+++ b/ami/lib/include/ami/csvread.h
@@ -1,6 +1,6 @@
 #ifndef _CSVREAD_H_
 #define _CSVREAD_H_
 
-char *ami_csvread_get_field_at_line(char *file, int index, char *field, int has_header);
+char *ami_csvread_get_field_at_line(ami_t *ami, char *file, int index, char *field, int has_header);
 
 #endif // _CSVREAD_H_


### PR DESCRIPTION
Added a new hash table in the ami object to keep track of the open file pointers so we are able to reuse such handles on the repeat loops, avoiding opening-closing the same files too many times.

It also includes a fix for the csv() function that was failing to parse line numbers provided as plain integers instead in a variable.